### PR TITLE
Fix table width sizing and risk highlight thresholds

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -21,6 +21,7 @@ type TableMode int
 const (
 	TableModeBasic TableMode = iota
 	TableModeProxycheck
+	compactTableExtraWidth = 2
 )
 
 // TableOptions controls how table output is rendered.
@@ -39,7 +40,6 @@ func RenderTable(results []model.Result, opts TableOptions, width int, enableCol
 	tw.SetStyle(tableStyle(enableColor))
 	tw.Style().Box.UnfinishedRow = "…"
 	if layout.width > 0 {
-		tw.Style().Size.WidthMin = layout.width
 		tw.Style().Size.WidthMax = layout.width
 	}
 	tw.SetColumnConfigs(layout.columnConfigs())
@@ -244,7 +244,7 @@ func riskRowColors(proxyCheck *model.ProxyCheck) text.Colors {
 	switch {
 	case *proxyCheck.Risk >= 75:
 		return text.Colors{text.BgHiRed, text.FgBlack}
-	case *proxyCheck.Risk >= 30:
+	case *proxyCheck.Risk >= 50:
 		return text.Colors{text.BgHiYellow, text.FgBlack}
 	default:
 		return nil
@@ -286,12 +286,14 @@ type tableLayout struct {
 }
 
 type tableColumn struct {
-	name    string
-	align   text.Align
-	min     int
-	grow    bool
-	width   int
-	natural int
+	name        string
+	align       text.Align
+	min         int
+	grow        bool
+	width       int
+	natural     int
+	preferExtra bool
+	shrinkFirst bool
 }
 
 func newTableLayout(results []model.Result, mode TableMode, enableColor bool, width int) tableLayout {
@@ -322,7 +324,7 @@ func buildProxycheckColumns(results []model.Result) []tableColumn {
 		{name: "ASN", align: text.AlignRight, min: 3, grow: false},
 		{name: "IP", min: 7, grow: true},
 		{name: "BGP Prefix", min: 10, grow: true},
-		{name: "AS Name", min: 12, grow: true},
+		{name: "AS Name", min: 12, grow: true, preferExtra: true, shrinkFirst: true},
 		{name: "Status", align: text.AlignCenter, min: 6, grow: false},
 		{name: "VPN Provider", min: 8, grow: true},
 		{name: "City", min: 6, grow: true},
@@ -354,7 +356,7 @@ func buildBasicColumns(results []model.Result) []tableColumn {
 		{name: "CC", align: text.AlignCenter, min: 2, grow: false},
 		{name: "Registry", min: 8, grow: true},
 		{name: "Allocated", align: text.AlignCenter, min: 10, grow: false},
-		{name: "AS Name", min: 12, grow: true},
+		{name: "AS Name", min: 12, grow: true, preferExtra: true, shrinkFirst: true},
 	}
 
 	for _, result := range results {
@@ -426,54 +428,57 @@ func (layout *tableLayout) assignWidths() {
 		return
 	}
 
-	total := 0
-	minTotal := 0
-	for _, column := range layout.columns {
-		total += column.width
-		minTotal += column.min
-	}
-
-	if total < available {
-		layout.growToWidth(available - total)
+	total := totalWidths(layout.columns)
+	if total <= available {
+		layout.growPreferred(min(available-total, compactTableExtraWidth))
 		return
 	}
-	if total > available {
-		layout.shrinkToWidth(total - available)
-	}
-	if totalWidths(layout.columns) < available {
-		layout.growToWidth(available - totalWidths(layout.columns))
-	}
+
+	layout.shrinkPreferred(total - available)
 	if totalWidths(layout.columns) > available {
 		layout.shrinkToWidth(totalWidths(layout.columns) - available)
 	}
+
+	minTotal := totalMinWidths(layout.columns)
 	if minTotal > available {
 		layout.forceShrinkToWidth(minTotal - available)
 	}
 }
 
-func (layout *tableLayout) growToWidth(extra int) {
+func (layout *tableLayout) growPreferred(extra int) {
 	if extra <= 0 {
 		return
 	}
 
-	growable := make([]int, 0, len(layout.columns))
+	preferred := make([]int, 0, len(layout.columns))
 	for idx, column := range layout.columns {
-		if column.grow {
-			growable = append(growable, idx)
+		if column.preferExtra {
+			preferred = append(preferred, idx)
 		}
 	}
-	if len(growable) == 0 {
+	if len(preferred) == 0 {
 		return
 	}
 
 	for extra > 0 {
-		for _, idx := range growable {
+		for _, idx := range preferred {
 			layout.columns[idx].width++
 			extra--
 			if extra == 0 {
 				return
 			}
 		}
+	}
+}
+
+func (layout *tableLayout) shrinkPreferred(overflow int) {
+	for overflow > 0 {
+		idx := layout.preferredShrinkableIndex()
+		if idx == -1 {
+			return
+		}
+		layout.columns[idx].width--
+		overflow--
 	}
 }
 
@@ -497,6 +502,25 @@ func (layout *tableLayout) forceShrinkToWidth(overflow int) {
 		layout.columns[idx].width--
 		overflow--
 	}
+}
+
+func (layout tableLayout) preferredShrinkableIndex() int {
+	best := -1
+	bestSlack := -1
+	for idx, column := range layout.columns {
+		if !column.shrinkFirst {
+			continue
+		}
+		slack := column.width - column.min
+		if slack <= 0 {
+			continue
+		}
+		if slack > bestSlack {
+			best = idx
+			bestSlack = slack
+		}
+	}
+	return best
 }
 
 func (layout tableLayout) widestShrinkableIndex() int {
@@ -570,6 +594,14 @@ func totalWidths(columns []tableColumn) int {
 	total := 0
 	for _, column := range columns {
 		total += column.width
+	}
+	return total
+}
+
+func totalMinWidths(columns []tableColumn) int {
+	total := 0
+	for _, column := range columns {
+		total += column.min
 	}
 	return total
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -171,7 +171,7 @@ func TestPrintTableProxycheckModeDoesNotRenderSCR(t *testing.T) {
 	}
 }
 
-func TestPrintTableUsesConfiguredWidth(t *testing.T) {
+func TestPrintTableKeepsCompactWidthWhenContentFits(t *testing.T) {
 	t.Setenv("COLUMNS", "100")
 
 	results := []model.Result{
@@ -182,7 +182,7 @@ func TestPrintTableUsesConfiguredWidth(t *testing.T) {
 			CC:        "US",
 			Registry:  "arin",
 			Allocated: "2020-01-01",
-			ASName:    "EXAMPLE-NETWORK-WITH-A-LONG-NAME",
+			ASName:    "TEST-NET",
 		},
 	}
 
@@ -193,8 +193,8 @@ func TestPrintTableUsesConfiguredWidth(t *testing.T) {
 	if len(lines) == 0 {
 		t.Fatal("expected rendered table output")
 	}
-	if width := len([]rune(lines[0])); width != 100 {
-		t.Fatalf("expected top border width 100, got %d: %q", width, lines[0])
+	if width := text.StringWidthWithoutEscSequences(lines[0]); width >= 100 {
+		t.Fatalf("expected compact top border width below 100, got %d: %q", width, lines[0])
 	}
 }
 
@@ -224,6 +224,41 @@ func TestPrintTableAvoidsTruncationWhenWidthAllows(t *testing.T) {
 	}
 	if strings.Contains(rendered, "…") {
 		t.Fatalf("did not expect truncation when enough width is available, got %q", rendered)
+	}
+	if width := firstRenderedLineWidth(rendered); width >= 240 {
+		t.Fatalf("expected rendered table to stay narrower than the terminal, got width %d: %q", width, rendered)
+	}
+}
+
+func TestRenderTableTruncatesASNameBeforeOtherColumns(t *testing.T) {
+	asName := "AN-EXTREMELY-LONG-AUTONOMOUS-SYSTEM-NAME"
+
+	rendered := RenderTable([]model.Result{
+		{
+			ASN:       64512,
+			IP:        "198.51.100.123",
+			BGPPrefix: "198.51.100.0/24",
+			CC:        "US",
+			Registry:  "arin",
+			Allocated: "2020-01-01",
+			ASName:    asName,
+		},
+	}, TableOptions{}, 95, false)
+
+	if !strings.Contains(rendered, "198.51.100.123") {
+		t.Fatalf("expected IP column to stay intact, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "198.51.100.0/24") {
+		t.Fatalf("expected BGP prefix column to stay intact, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "arin") || !strings.Contains(rendered, "2020-01-01") {
+		t.Fatalf("expected non-AS identity fields to stay intact, got %q", rendered)
+	}
+	if strings.Contains(rendered, asName) {
+		t.Fatalf("expected AS name to truncate before other columns, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "…") {
+		t.Fatalf("expected AS name truncation ellipsis, got %q", rendered)
 	}
 }
 
@@ -266,6 +301,43 @@ func TestRenderTableHighlightsRiskRowsInProxycheckMode(t *testing.T) {
 	}
 }
 
+func TestRenderTableOnlyHighlightsYellowAtRisk50AndAbove(t *testing.T) {
+	justBelowYellow := 49
+	atYellow := 50
+
+	rendered := RenderTable([]model.Result{
+		{
+			ASN:       64523,
+			IP:        "198.51.100.23",
+			BGPPrefix: "198.51.100.0/24",
+			ASName:    "BELOW-YELLOW",
+			ProxyCheck: &model.ProxyCheck{
+				Risk: &justBelowYellow,
+			},
+		},
+		{
+			ASN:       64524,
+			IP:        "198.51.100.24",
+			BGPPrefix: "198.51.100.0/24",
+			ASName:    "AT-YELLOW",
+			ProxyCheck: &model.ProxyCheck{
+				Risk: &atYellow,
+			},
+		},
+	}, TableOptions{Mode: TableModeProxycheck}, 180, true)
+
+	yellow := (text.Colors{text.BgHiYellow, text.FgBlack}).EscapeSeq()
+	highlightedRows := 0
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, yellow) {
+			highlightedRows++
+		}
+	}
+	if highlightedRows != 1 {
+		t.Fatalf("expected exactly one yellow-highlighted row at the 50 threshold, got %q", rendered)
+	}
+}
+
 func TestRenderTableDoesNotHighlightRiskRowsOutsideProxycheckMode(t *testing.T) {
 	highRisk := 90
 	result := []model.Result{
@@ -289,4 +361,12 @@ func TestRenderTableDoesNotHighlightRiskRowsOutsideProxycheckMode(t *testing.T) 
 	if strings.Contains(basicRendered, (text.Colors{text.BgHiRed, text.FgBlack}).EscapeSeq()) || strings.Contains(basicRendered, (text.Colors{text.BgHiYellow, text.FgBlack}).EscapeSeq()) {
 		t.Fatalf("did not expect row highlights outside proxycheck mode, got %q", basicRendered)
 	}
+}
+
+func firstRenderedLineWidth(rendered string) int {
+	lines := strings.Split(strings.TrimRight(rendered, "\n"), "\n")
+	if len(lines) == 0 {
+		return 0
+	}
+	return text.StringWidthWithoutEscSequences(lines[0])
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/jedib0t/go-pretty/v6/text"
 
 	"ip2asn/internal/model"
 	"ip2asn/internal/output"
@@ -65,6 +66,13 @@ func TestModelResizeRendersTableAndFooter(t *testing.T) {
 	}
 	if !strings.Contains(view.Content, "q quit") {
 		t.Fatalf("expected help footer in view content, got %q", view.Content)
+	}
+	lines := strings.Split(view.Content, "\n")
+	if len(lines) == 0 {
+		t.Fatal("expected rendered table lines in view content")
+	}
+	if width := text.StringWidthWithoutEscSequences(strings.TrimRight(lines[0], " ")); width >= 160 {
+		t.Fatalf("expected visible table width below window width, got %d: %q", width, lines[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep table and TUI output compact instead of forcing full terminal width
- prioritize AS Name for extra width and first-pass truncation under tight widths
- adjust yellow risk row highlighting to start at 50 and add boundary coverage

## Testing
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated risk highlighting threshold: Yellow background now applies at Risk ≥ 50 (previously ≥ 30).

* **Improvements**
  * Refined table rendering with improved column width negotiation.
  * Enhanced column prioritization to better preserve important fields when display space is limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->